### PR TITLE
fix the memory leaks in na tray expose-event.

### DIFF
--- a/indicator-application/na-tray.c
+++ b/indicator-application/na-tray.c
@@ -632,7 +632,11 @@ na_tray_expose_icon (GtkWidget *widget,
                                    allocation.y);
         cairo_rectangle (cr, 0, allocation.y, allocation.width, allocation.height);
       }
-      
+
+      g_object_unref (panel_orientation);
+      if (tmp) {
+        g_free (tmp); 
+      }
       cairo_clip (cr);
 #else
       gdk_cairo_set_source_pixmap (cr,


### PR DESCRIPTION
绘制事件可能会被频繁触发，如果没有释放资源就会导致严重的内存泄漏，这个问题在运行wine应用（qq或微信）的时候表现的很突出，估计是因为图标闪烁频繁的触发了这一段代码。

另外，gtk3已经把GtkWidget的expose-event信号用draw取代了，没想到这个signal居然还能用。。。我认为现在的版本使用GTK_CHECKE_VERSION进行判断是不必要的，也许要把这一块的修改迁移到gtk3的代码上。